### PR TITLE
Changed the wording on question number two.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 1) Where did you find this bug? <!-- Ingame, online, etc. (Note, if the bug is a missing URL, it is technically online, but report how you got to the link) -->
 
 
-2) Screenshots/Videos showing the bug. <!-- The *entire* minecraft/web browser screen is needed. Feel free to cover any info you don't want revealed. Usually only a screenshot is needed and no other info is needed, but fill out the rest anyway. -->
+2) Screenshots/Videos showing the bug. <!-- The *entire* minecraft/web browser screen is needed. Feel free to cover any info you don't want to be revealed. Usually, only a screenshot is needed and no other info is needed, but fill out the rest anyway. -->
 
 
 3) _Brief_ explanation of the bug. <!-- We need it brief, no need to over-complicate it -->


### PR DESCRIPTION
The *entire* minecraft/web browser screen is needed. Feel free to cover any info you don't want `to be` revealed. Usually`,` only a screenshot is needed and no other info is needed, but fill out the rest anyway.
>Added the "to be" in front of `revealed` 
>Added a comma after `usually`